### PR TITLE
Bli kvitt avhengighet til dateutil

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 bottle
-dateutil
 requests

--- a/ruterstop.py
+++ b/ruterstop.py
@@ -111,13 +111,18 @@ def parse_departures(raw_dict, *, date_fmt="%Y-%m-%dT%H:%M:%S%z"):
     return a list of Departure objects.
 
     Parsing relies on date format being exactly as specified in date_fmt.
+
+    Date is stored as time-zone unaware to avoid relying on a date parsing
+    library to handle time-zones.
     """
     if raw_dict["data"]["stopPlace"]:
         for dep in raw_dict["data"]["stopPlace"]["estimatedCalls"]:
+            eta = datetime.strptime(dep["expectedArrivalTime"],
+                                    date_fmt).replace(tzinfo=None)
             yield Departure(
                 line=dep["serviceJourney"]["line"]["publicCode"],
                 name=norwegian_ascii(dep["destinationDisplay"]["frontText"]),
-                eta=datetime.strptime(dep["expectedArrivalTime"], date_fmt),
+                eta=eta,
                 direction=dep["serviceJourney"]["directionType"]
             )
 

--- a/ruterstop.py
+++ b/ruterstop.py
@@ -13,7 +13,6 @@ import re
 import socket
 from collections import namedtuple
 from datetime import datetime, timedelta
-import dateutil.parser
 
 import requests
 import bottle
@@ -106,17 +105,19 @@ def get_realtime_stop(*, stop_id=None):
     return res.json()
 
 
-def parse_departures(raw_dict):
+def parse_departures(raw_dict, *, date_fmt="%Y-%m-%dT%H:%M:%S%z"):
     """
     Parse a JSON response dict from EnTur JourneyPlanner API and
     return a list of Departure objects.
+
+    Parsing relies on date format being exactly as specified in date_fmt.
     """
     if raw_dict["data"]["stopPlace"]:
         for dep in raw_dict["data"]["stopPlace"]["estimatedCalls"]:
             yield Departure(
                 line=dep["serviceJourney"]["line"]["publicCode"],
                 name=norwegian_ascii(dep["destinationDisplay"]["frontText"]),
-                eta=dateutil.parser.parse(dep["expectedArrivalTime"], ignoretz=True),
+                eta=datetime.strptime(dep["expectedArrivalTime"], date_fmt),
                 direction=dep["serviceJourney"]["directionType"]
             )
 


### PR DESCRIPTION
Det gjør at datoer ikke tar hensyn til tidssoner, men antakelig brukes dette programmet bare på maskiner som er i samme tidssone som EnTur API'et.
Parsingen av tider er veldig strengt definert, så dersom det skjer noe med datoformatet fra API'et vil programmet kræsje.