### PR TITLE
Fjern første argument fra sys.argv ved parsing

### DIFF
--- a/ruterstop.py
+++ b/ruterstop.py
@@ -170,7 +170,7 @@ def main(argv, *, stdout=sys.stdout):
     par.add_argument('--debug', action="store_true",
                      help="enable debug logging")
 
-    args = par.parse_args(argv)
+    args = par.parse_args(argv[1:])
 
     if args.debug:
         logging.basicConfig(level=logging.DEBUG)

--- a/tests/test_ruterstop.py
+++ b/tests/test_ruterstop.py
@@ -168,7 +168,7 @@ class CommandLineInterfaceTestCase(unittest.TestCase):
 
         with freeze_time(self.first_departure_time):
             # Call CLI with custom args
-            api.main(["--stop-id", "1337"], stdout=stdout)
+            api.main([None, "--stop-id", "1337"], stdout=stdout)
             self.patched_get_realtime_stop.assert_called_once_with(stop_id="1337")
 
             actual = filter(None, stdout.getvalue().split('\n')) # remove empty lines


### PR DESCRIPTION
Misset dette i testene, og stolte for mye på de.
Alltid test applikasjonen manuelt i tillegg før merge!